### PR TITLE
Feat/sync bitacora finalization

### DIFF
--- a/src/components/BitacoraEntryCard.vue
+++ b/src/components/BitacoraEntryCard.vue
@@ -1,0 +1,168 @@
+<template>
+  <v-card class="mb-4" outlined>
+    <v-card-title class="d-flex justify-space-between">
+      <span>{{ actividadNombre }}</span>
+      <v-chip size="small" :color="estadoColor" label>{{ entry.estado_ejecucion }}</v-chip>
+    </v-card-title>
+    <v-card-subtitle>
+      {{ formatDate(entry.fecha_ejecucion) }}
+      <span v-if="tipoActividadNombre"> | Tipo: {{ tipoActividadNombre }}</span>
+    </v-card-subtitle>
+
+    <v-divider></v-divider>
+
+    <v-card-text>
+      <v-list dense>
+        <v-list-item v-if="siembraNombre">
+          <template v-slot:prepend><v-icon>mdi-sprout</v-icon></template>
+          <v-list-item-title>Siembra</v-list-item-title>
+          <v-list-item-subtitle>{{ siembraNombre }}</v-list-item-subtitle>
+        </v-list-item>
+
+        <v-list-item v-if="responsableName">
+          <template v-slot:prepend><v-icon>mdi-account</v-icon></template>
+          <v-list-item-title>Responsable</v-list-item-title>
+          <v-list-item-subtitle>{{ responsableName }}</v-list-item-subtitle>
+        </v-list-item>
+
+        <v-list-item v-if="entry.programacion_origen">
+          <template v-slot:prepend><v-icon>mdi-calendar-clock</v-icon></template>
+          <v-list-item-title>Programación Origen</v-list-item-title>
+          <v-list-item-subtitle>{{ entry.programacion_origen }}</v-list-item-subtitle>
+        </v-list-item>
+
+        <v-list-item v-if="entry.notas">
+          <template v-slot:prepend><v-icon>mdi-note-text</v-icon></template>
+          <v-list-item-title>Notas</v-list-item-title>
+          <v-list-item-subtitle class="text-wrap">{{ entry.notas }}</v-list-item-subtitle>
+        </v-list-item>
+      </v-list>
+
+      <div v-if="formatoReporteColumnas && formatoReporteColumnas.length > 0 && entry.metricas" class="mt-3">
+        <h4 class="text-subtitle-1 mb-1">Detalles de Actividad:</h4>
+        <v-table dense class="text-caption">
+          <thead>
+            <tr>
+              <th class="text-left">Métrica</th>
+              <th class="text-left">Valor</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="columna in formatoReporteColumnas" :key="columna.metrica || columna.nombre">
+              <td>{{ columna.nombre }}</td>
+              <td>
+                <span v-if="getMetricaValue(columna.metrica) !== undefined">
+                  {{ getMetricaValue(columna.metrica) }}
+                </span>
+                <em v-else-if="columna.tipo === 'text' && entry.metricas && entry.metricas[columna.nombre]"> <!-- For direct text like Observaciones -->
+                  {{ entry.metricas[columna.nombre] }}
+                </em>
+                <em v-else>No registrado</em>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </div>
+      <div v-else-if="entry.metricas && Object.keys(entry.metricas).length > 0 && (!formatoReporteColumnas || formatoReporteColumnas.length === 0)" class="mt-3">
+         <h4 class="text-subtitle-1 mb-1">Metricas Registradas (sin formato):</h4>
+         <v-list dense>
+            <v-list-item v-for="(value, key) in entry.metricas" :key="key">
+                 <v-list-item-title>{{ key }}: {{ value }}</v-list-item-title>
+            </v-list-item>
+         </v-list>
+      </div>
+
+    </v-card-text>
+    <v-divider v-if="entry.id"></v-divider>
+     <v-card-actions v-if="entry.id">
+        <v-spacer></v-spacer>
+        <v-chip variant="outlined" size="x-small" pill>ID: {{ entry.id }}</v-chip>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  entry: {
+    type: Object,
+    required: true,
+  },
+});
+
+// Helper to safely access nested properties
+const getSafe = (fn, defaultValue = '') => {
+  try {
+    const value = fn();
+    // Ensure that if value is an empty object (from a failed expand but existing field), it's treated as defaultValue
+    if (typeof value === 'object' && value !== null && Object.keys(value).length === 0 && defaultValue === '') {
+        return defaultValue;
+    }
+    return value === undefined || value === null ? defaultValue : value;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+const actividadNombre = computed(() => getSafe(() => props.entry.expand.actividad_realizada.nombre, 'Actividad Desconocida'));
+const tipoActividadNombre = computed(() => getSafe(() => props.entry.expand.actividad_realizada.expand.tipo_actividades.nombre));
+const siembraNombre = computed(() => getSafe(() => props.entry.expand.siembra_asociada.nombre));
+const responsableName = computed(() => getSafe(() => props.entry.expand.user_responsable.name, getSafe(() => props.entry.expand.user_responsable.username, 'No asignado')));
+
+const estadoColor = computed(() => {
+  switch (props.entry.estado_ejecucion?.toLowerCase()) {
+    case 'completado': return 'green';
+    case 'en_progreso': return 'blue';
+    case 'planificada': return 'orange';
+    case 'cancelada': return 'red';
+    default: return 'grey';
+  }
+});
+
+const formatoReporteColumnas = computed(() => {
+  return getSafe(() => props.entry.expand.actividad_realizada.expand.tipo_actividades.formato_reporte.columnas, []);
+});
+
+const bitacoraMetricasValues = computed(() => {
+  return getSafe(() => props.entry.metricas, {});
+});
+
+function getMetricaValue(metricaKey) {
+  // metricaKey comes from formato_reporte.columnas[n].metrica
+  // This key should directly map to a key in the bitacora entry's own 'metricas' field.
+  // Return undefined if not found, so v-if can distinguish between "not found" and a legitimate falsy value like 0 or false.
+  return bitacoraMetricasValues.value[metricaKey];
+}
+
+function formatDate(dateString) {
+  if (!dateString) return 'Fecha no disponible';
+  try {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return 'Fecha inválida';
+    // Use toLocaleString for a more user-friendly date and time format
+    return date.toLocaleString(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true });
+  } catch (e) {
+    return 'Fecha inválida';
+  }
+}
+
+</script>
+
+<style scoped>
+/* Tailwind classes can be used here if needed, e.g., for margin/padding adjustments */
+.v-card-title span {
+  word-break: break-word; /* Ensure long activity names wrap */
+}
+.text-caption { /* Vuetify utility, but ensure it's available or define if needed */
+    font-size: 0.75rem !important;
+    line-height: 1.25rem;
+}
+.text-wrap { /* Vuetify utility */
+    white-space: pre-wrap !important;
+    word-wrap: break-word !important;
+}
+.v-list-item-subtitle {
+  white-space: normal; /* Allow subtitles to wrap */
+}
+</style>

--- a/src/components/BitacoraView.vue
+++ b/src/components/BitacoraView.vue
@@ -1,0 +1,231 @@
+<template>
+  <div class="bitacora-view">
+    <h2>Bitácora de Actividades</h2>
+
+    <div v-if="isLoading" class="loading">Cargando entradas...</div>
+
+    <div v-if="error" class="error-message">
+      <p>Error cargando la bitácora: {{ error.message }}</p>
+    </div>
+
+    <div v-if="!isLoading && entries.length === 0 && !error" class="no-entries">
+      No hay entradas en la bitácora para mostrar.
+    </div>
+
+    <div v-if="entries.length > 0" class="entries-list">
+      <div class="filters">
+        <label for="filterType">Filtrar por:</label>
+        <select id="filterType" v-model="filterType">
+          <option value="all">Todas</option>
+          <option value="siembra">Siembra</option>
+          <option value="programacion">Programación</option>
+        </select>
+
+        <input 
+          v-if="filterType === 'siembra'" 
+          v-model="filterSiembraId" 
+          placeholder="ID de Siembra"
+        />
+        <input 
+          v-if="filterType === 'programacion'" 
+          v-model="filterProgramacionId" 
+          placeholder="ID de Programación"
+        />
+        <button @click="applyFilter">Aplicar Filtro</button>
+      </div>
+
+      <ul>
+        <li v-for="entry in displayedEntries" :key="entry.id" class="bitacora-entry">
+          <div class="entry-header">
+            <strong>Actividad:</strong> {{ entry.actividad_realizada_nombre || entry.actividad_realizada }} 
+            <span class="entry-date">({{ formatDate(entry.fecha_ejecucion) }})</span>
+          </div>
+          <div class_="entry-details">
+            <p v-if="entry.programacion_origen"><strong>Programación Origen:</strong> {{ entry.programacion_origen }}</p>
+            <p v-if="entry.siembra_asociada_nombre || entry.siembra_asociada"><strong>Siembra:</strong> {{ entry.siembra_asociada_nombre || entry.siembra_asociada }}</p>
+            <p><strong>Estado:</strong> {{ entry.estado_ejecucion }}</p>
+            <p v-if="entry.user_responsable_nombre || entry.user_responsable"><strong>Responsable:</strong> {{ entry.user_responsable_nombre || entry.user_responsable }}</p>
+            <p v-if="entry.notas"><strong>Notas:</strong> {{ entry.notas }}</p>
+            <small class="entry-id">ID: {{ entry.id }}</small>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed, watch } from 'vue';
+import { useBitacoraStore } from '@/stores/bitacoraStore';
+import { useHaciendaStore } from '@/stores/haciendaStore';
+// For fetching names for related IDs (optional enhancement)
+// import { useActividadesStore } from '@/stores/actividadesStore';
+// import { useSiembrasStore } from '@/stores/siembrasStore';
+// import { useProfileStore } from '@/stores/profileStore'; // Assuming user names are here
+
+const bitacoraStore = useBitacoraStore();
+const haciendaStore = useHaciendaStore();
+// const actividadesStore = useActividadesStore(); // Optional
+// const siembrasStore = useSiembrasStore(); // Optional
+// const profileStore = useProfileStore(); // Optional
+
+
+const isLoading = ref(false);
+const error = ref(null);
+const entries = ref([]);
+
+const filterType = ref('all'); // 'all', 'siembra', 'programacion'
+const filterSiembraId = ref('');
+const filterProgramacionId = ref('');
+
+// Fetch initial data (all entries for the hacienda)
+onMounted(async () => {
+  isLoading.value = true;
+  error.value = null;
+  try {
+    // Ensure bitacoraStore is initialized (loads from localStorage or fetches)
+    if (!bitacoraStore.lastSync && haciendaStore.mi_hacienda?.id) {
+        // If never synced, call init or cargar directly
+        await bitacoraStore.init(); // or await bitacoraStore.cargarBitacoraEntries(haciendaStore.mi_hacienda.id);
+    }
+    // Entries are now reactive from the store's state if store is designed reactively
+    // If not, we might need to explicitly assign them after load.
+    // For this component, let's assume we just need to trigger loading if not already done.
+  } catch (e) {
+    console.error('Error loading bitacora entries:', e);
+    error.value = e;
+  } finally {
+    isLoading.value = false;
+  }
+});
+
+// Watch for changes in store's entries (if store state is directly used)
+// This makes the component reactive to store updates from sync, etc.
+watch(() => bitacoraStore.bitacoraEntries, (newEntries) => {
+  entries.value = newEntries.map(entry => enrichEntry(entry));
+}, { immediate: true, deep: true });
+
+const displayedEntries = computed(() => {
+  if (filterType.value === 'all') {
+    return entries.value;
+  } else if (filterType.value === 'siembra' && filterSiembraId.value) {
+    return entries.value.filter(e => e.siembra_asociada === filterSiembraId.value);
+  } else if (filterType.value === 'programacion' && filterProgramacionId.value) {
+    return entries.value.filter(e => e.programacion_origen === filterProgramacionId.value);
+  }
+  return entries.value; // Fallback
+});
+
+function applyFilter() {
+  // The computed property `displayedEntries` will update automatically
+  // when filterType, filterSiembraId, or filterProgramacionId change.
+  // This function can be used if a manual trigger for filtering is desired,
+  // but with the current computed property, it's mostly for show or future complex logic.
+  console.log("Applying filter:", filterType.value, filterSiembraId.value, filterProgramacionId.value);
+}
+
+// Helper to format date
+function formatDate(dateString) {
+  if (!dateString) return 'Fecha no disponible';
+  const date = new Date(dateString);
+  return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+}
+
+// Optional: Helper to enrich entries with names from related stores
+// This is a basic version. A more robust solution might involve getters in the bitacoraStore
+// or more sophisticated data fetching/joining.
+function enrichEntry(entry) {
+  const enriched = { ...entry };
+  // Example: (uncomment and adapt if these stores are used)
+  /*
+  if (entry.actividad_realizada) {
+    const actividad = actividadesStore.actividades.find(a => a.id === entry.actividad_realizada);
+    enriched.actividad_realizada_nombre = actividad?.nombre || entry.actividad_realizada;
+  }
+  if (entry.siembra_asociada) {
+    const siembra = siembrasStore.siembras.find(s => s.id === entry.siembra_asociada);
+    enriched.siembra_asociada_nombre = siembra?.nombre || entry.siembra_asociada;
+  }
+  if (entry.user_responsable) {
+    // Profile store might need a getter like `getUserById`
+    // const user = profileStore.getUserById(entry.user_responsable); 
+    // enriched.user_responsable_nombre = user?.name || entry.user_responsable;
+  }
+  */
+  return enriched;
+}
+
+</script>
+
+<style scoped>
+.bitacora-view {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+}
+.loading, .no-entries, .error-message {
+  text-align: center;
+  padding: 20px;
+  color: #666;
+}
+.error-message {
+  color: red;
+  border: 1px solid red;
+  background-color: #ffebeb;
+}
+.filters {
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: #f9f9f9;
+  border-radius: 5px;
+}
+.filters label {
+  margin-right: 10px;
+}
+.filters select, .filters input {
+  margin-right: 10px;
+  padding: 8px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+}
+.filters button {
+  padding: 8px 15px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.filters button:hover {
+  background-color: #0056b3;
+}
+.entries-list ul {
+  list-style-type: none;
+  padding: 0;
+}
+.bitacora-entry {
+  background-color: #fff;
+  border: 1px solid #eee;
+  border-radius: 5px;
+  padding: 15px;
+  margin-bottom: 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.entry-header {
+  font-size: 1.1em;
+  margin-bottom: 10px;
+}
+.entry-date {
+  font-size: 0.9em;
+  color: #777;
+}
+.entry-details p {
+  margin: 5px 0;
+  font-size: 0.95em;
+}
+.entry-id {
+  font-size: 0.8em;
+  color: #aaa;
+  display: block;
+  margin-top: 10px;
+}
+</style>

--- a/src/components/BitacoraView.vue
+++ b/src/components/BitacoraView.vue
@@ -1,231 +1,213 @@
 <template>
-  <div class="bitacora-view">
-    <h2>Bitácora de Actividades</h2>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12">
+        <v-card>
+          <v-card-title class="headline">Bitácora General de Actividades</v-card-title>
+          <v-card-subtitle>Todas las entradas registradas para la hacienda actual.</v-card-subtitle>
+        </v-card>
+      </v-col>
+    </v-row>
 
-    <div v-if="isLoading" class="loading">Cargando entradas...</div>
+    <v-row>
+      <v-col cols="12">
+        <v-expansion-panels class="mb-4">
+          <v-expansion-panel>
+            <v-expansion-panel-title>
+              <v-icon start>mdi-filter-variant</v-icon>
+              Filtros
+            </v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <v-row dense>
+                <v-col cols="12" md="4">
+                  <v-select
+                    v-model="filterSiembraId"
+                    :items="siembrasForFilter"
+                    item-title="nombre"
+                    item-value="id"
+                    label="Filtrar por Siembra"
+                    clearable
+                    dense
+                    hide-details
+                  ></v-select>
+                </v-col>
+                <v-col cols="12" md="4">
+                  <v-select
+                    v-model="filterActividadId"
+                    :items="actividadesForFilter"
+                    item-title="nombre"
+                    item-value="id"
+                    label="Filtrar por Actividad"
+                    clearable
+                    dense
+                    hide-details
+                  ></v-select>
+                </v-col>
+                <v-col cols="12" md="4">
+                  <v-text-field
+                    v-model="filterDate"
+                    label="Filtrar por Fecha (YYYY-MM-DD)"
+                    type="date"
+                    clearable
+                    dense
+                    hide-details
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
 
-    <div v-if="error" class="error-message">
-      <p>Error cargando la bitácora: {{ error.message }}</p>
-    </div>
+    <v-row v-if="isLoading">
+      <v-col cols="12" class="text-center">
+        <v-progress-circular indeterminate color="primary"></v-progress-circular>
+        <p>Cargando bitácora...</p>
+      </v-col>
+    </v-row>
 
-    <div v-if="!isLoading && entries.length === 0 && !error" class="no-entries">
-      No hay entradas en la bitácora para mostrar.
-    </div>
+    <v-row v-if="!isLoading && error">
+      <v-col cols="12">
+        <v-alert type="error" prominent>
+          Error cargando la bitácora: {{ error.message || error }}
+        </v-alert>
+      </v-col>
+    </v-row>
 
-    <div v-if="entries.length > 0" class="entries-list">
-      <div class="filters">
-        <label for="filterType">Filtrar por:</label>
-        <select id="filterType" v-model="filterType">
-          <option value="all">Todas</option>
-          <option value="siembra">Siembra</option>
-          <option value="programacion">Programación</option>
-        </select>
+    <v-row v-if="!isLoading && displayedEntries.length === 0 && !error">
+      <v-col cols="12">
+        <v-alert type="info" class="text-center">
+          No hay entradas en la bitácora que coincidan con los filtros aplicados, o no hay entradas registradas aún.
+        </v-alert>
+      </v-col>
+    </v-row>
 
-        <input 
-          v-if="filterType === 'siembra'" 
-          v-model="filterSiembraId" 
-          placeholder="ID de Siembra"
-        />
-        <input 
-          v-if="filterType === 'programacion'" 
-          v-model="filterProgramacionId" 
-          placeholder="ID de Programación"
-        />
-        <button @click="applyFilter">Aplicar Filtro</button>
-      </div>
+    <v-row v-if="!isLoading && displayedEntries.length > 0">
+      <v-col
+        v-for="entry in displayedEntries"
+        :key="entry.id"
+        cols="12"
+        md="6" 
+        lg="4" 
+      >
+        <BitacoraEntryCard :entry="entry" />
+      </v-col>
+    </v-row>
+    
+    <v-row v-if="!isLoading && displayedEntries.length > 0 && paginatedEntries.length < filteredEntries.length" class="mt-4">
+        <v-col class="text-center">
+            <v-btn @click="loadMore" color="primary">Cargar Más</v-btn>
+        </v-col>
+    </v-row>
 
-      <ul>
-        <li v-for="entry in displayedEntries" :key="entry.id" class="bitacora-entry">
-          <div class="entry-header">
-            <strong>Actividad:</strong> {{ entry.actividad_realizada_nombre || entry.actividad_realizada }} 
-            <span class="entry-date">({{ formatDate(entry.fecha_ejecucion) }})</span>
-          </div>
-          <div class_="entry-details">
-            <p v-if="entry.programacion_origen"><strong>Programación Origen:</strong> {{ entry.programacion_origen }}</p>
-            <p v-if="entry.siembra_asociada_nombre || entry.siembra_asociada"><strong>Siembra:</strong> {{ entry.siembra_asociada_nombre || entry.siembra_asociada }}</p>
-            <p><strong>Estado:</strong> {{ entry.estado_ejecucion }}</p>
-            <p v-if="entry.user_responsable_nombre || entry.user_responsable"><strong>Responsable:</strong> {{ entry.user_responsable_nombre || entry.user_responsable }}</p>
-            <p v-if="entry.notas"><strong>Notas:</strong> {{ entry.notas }}</p>
-            <small class="entry-id">ID: {{ entry.id }}</small>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
+  </v-container>
 </template>
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue';
 import { useBitacoraStore } from '@/stores/bitacoraStore';
 import { useHaciendaStore } from '@/stores/haciendaStore';
-// For fetching names for related IDs (optional enhancement)
-// import { useActividadesStore } from '@/stores/actividadesStore';
-// import { useSiembrasStore } from '@/stores/siembrasStore';
-// import { useProfileStore } from '@/stores/profileStore'; // Assuming user names are here
+import { useSiembrasStore } from '@/stores/siembrasStore'; // For filter
+import { useActividadesStore } from '@/stores/actividadesStore'; // For filter
+import BitacoraEntryCard from './BitacoraEntryCard.vue'; // Import the new card component
 
 const bitacoraStore = useBitacoraStore();
 const haciendaStore = useHaciendaStore();
-// const actividadesStore = useActividadesStore(); // Optional
-// const siembrasStore = useSiembrasStore(); // Optional
-// const profileStore = useProfileStore(); // Optional
-
+const siembrasStore = useSiembrasStore();
+const actividadesStore = useActividadesStore();
 
 const isLoading = ref(false);
 const error = ref(null);
-const entries = ref([]);
 
-const filterType = ref('all'); // 'all', 'siembra', 'programacion'
-const filterSiembraId = ref('');
-const filterProgramacionId = ref('');
+// Filters
+const filterSiembraId = ref(null);
+const filterActividadId = ref(null);
+const filterDate = ref(null); // Store date as YYYY-MM-DD string
 
-// Fetch initial data (all entries for the hacienda)
+const itemsPerPage = ref(9); // Number of cards to load initially and per "load more"
+const currentPage = ref(1);
+
+// Ensure dependent stores are initialized for filters
 onMounted(async () => {
   isLoading.value = true;
   error.value = null;
   try {
-    // Ensure bitacoraStore is initialized (loads from localStorage or fetches)
-    if (!bitacoraStore.lastSync && haciendaStore.mi_hacienda?.id) {
-        // If never synced, call init or cargar directly
-        await bitacoraStore.init(); // or await bitacoraStore.cargarBitacoraEntries(haciendaStore.mi_hacienda.id);
+    // Init master data for filters if not already loaded
+    if (siembrasStore.siembras.length === 0) {
+      await siembrasStore.init(haciendaStore.mi_hacienda?.id);
     }
-    // Entries are now reactive from the store's state if store is designed reactively
-    // If not, we might need to explicitly assign them after load.
-    // For this component, let's assume we just need to trigger loading if not already done.
+    if (actividadesStore.actividades.length === 0) {
+      await actividadesStore.init(haciendaStore.mi_hacienda?.id);
+    }
+
+    // Init bitacoraStore (loads from localStorage or fetches)
+    // The store itself handles not re-fetching if data is recent via its `lastSync`
+    await bitacoraStore.init(); 
+
   } catch (e) {
-    console.error('Error loading bitacora entries:', e);
+    console.error('Error initializing BitacoraView or dependent stores:', e);
     error.value = e;
   } finally {
     isLoading.value = false;
   }
 });
 
-// Watch for changes in store's entries (if store state is directly used)
-// This makes the component reactive to store updates from sync, etc.
-watch(() => bitacoraStore.bitacoraEntries, (newEntries) => {
-  entries.value = newEntries.map(entry => enrichEntry(entry));
-}, { immediate: true, deep: true });
-
-const displayedEntries = computed(() => {
-  if (filterType.value === 'all') {
-    return entries.value;
-  } else if (filterType.value === 'siembra' && filterSiembraId.value) {
-    return entries.value.filter(e => e.siembra_asociada === filterSiembraId.value);
-  } else if (filterType.value === 'programacion' && filterProgramacionId.value) {
-    return entries.value.filter(e => e.programacion_origen === filterProgramacionId.value);
-  }
-  return entries.value; // Fallback
+// Get all enriched entries from the store
+const allEnrichedEntries = computed(() => {
+    // Using the getter that returns already sorted entries (newest first)
+    return bitacoraStore.getEnrichedBitacoraEntries || []; 
 });
 
-function applyFilter() {
-  // The computed property `displayedEntries` will update automatically
-  // when filterType, filterSiembraId, or filterProgramacionId change.
-  // This function can be used if a manual trigger for filtering is desired,
-  // but with the current computed property, it's mostly for show or future complex logic.
-  console.log("Applying filter:", filterType.value, filterSiembraId.value, filterProgramacionId.value);
-}
+const filteredEntries = computed(() => {
+  let entries = allEnrichedEntries.value;
 
-// Helper to format date
-function formatDate(dateString) {
-  if (!dateString) return 'Fecha no disponible';
-  const date = new Date(dateString);
-  return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
-}
+  if (filterSiembraId.value) {
+    entries = entries.filter(entry => entry.siembra_asociada === filterSiembraId.value || entry.expand?.siembra_asociada?.id === filterSiembraId.value);
+  }
+  if (filterActividadId.value) {
+    entries = entries.filter(entry => entry.actividad_realizada === filterActividadId.value || entry.expand?.actividad_realizada?.id === filterActividadId.value);
+  }
+  if (filterDate.value) {
+    entries = entries.filter(entry => {
+      if (!entry.fecha_ejecucion) return false;
+      // Compare only date part, ignoring time
+      const entryDate = entry.fecha_ejecucion.substring(0, 10);
+      return entryDate === filterDate.value;
+    });
+  }
+  return entries;
+});
 
-// Optional: Helper to enrich entries with names from related stores
-// This is a basic version. A more robust solution might involve getters in the bitacoraStore
-// or more sophisticated data fetching/joining.
-function enrichEntry(entry) {
-  const enriched = { ...entry };
-  // Example: (uncomment and adapt if these stores are used)
-  /*
-  if (entry.actividad_realizada) {
-    const actividad = actividadesStore.actividades.find(a => a.id === entry.actividad_realizada);
-    enriched.actividad_realizada_nombre = actividad?.nombre || entry.actividad_realizada;
-  }
-  if (entry.siembra_asociada) {
-    const siembra = siembrasStore.siembras.find(s => s.id === entry.siembra_asociada);
-    enriched.siembra_asociada_nombre = siembra?.nombre || entry.siembra_asociada;
-  }
-  if (entry.user_responsable) {
-    // Profile store might need a getter like `getUserById`
-    // const user = profileStore.getUserById(entry.user_responsable); 
-    // enriched.user_responsable_nombre = user?.name || entry.user_responsable;
-  }
-  */
-  return enriched;
+const paginatedEntries = computed(() => {
+    const end = currentPage.value * itemsPerPage.value;
+    return filteredEntries.value.slice(0, end);
+});
+
+// Use paginatedEntries for display
+const displayedEntries = computed(() => paginatedEntries.value);
+
+const siembrasForFilter = computed(() => {
+  return siembrasStore.siembras.map(s => ({ id: s.id, nombre: s.nombre }));
+});
+
+const actividadesForFilter = computed(() => {
+  return actividadesStore.actividades.map(a => ({ id: a.id, nombre: a.nombre }));
+});
+
+watch([filterSiembraId, filterActividadId, filterDate], () => {
+    currentPage.value = 1; // Reset to first page on filter change
+});
+
+function loadMore() {
+    currentPage.value += 1;
 }
 
 </script>
 
 <style scoped>
-.bitacora-view {
-  padding: 20px;
-  font-family: Arial, sans-serif;
-}
-.loading, .no-entries, .error-message {
-  text-align: center;
-  padding: 20px;
-  color: #666;
-}
-.error-message {
-  color: red;
-  border: 1px solid red;
-  background-color: #ffebeb;
-}
-.filters {
-  margin-bottom: 20px;
-  padding: 10px;
-  background-color: #f9f9f9;
-  border-radius: 5px;
-}
-.filters label {
-  margin-right: 10px;
-}
-.filters select, .filters input {
-  margin-right: 10px;
-  padding: 8px;
-  border-radius: 3px;
-  border: 1px solid #ccc;
-}
-.filters button {
-  padding: 8px 15px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-}
-.filters button:hover {
-  background-color: #0056b3;
-}
-.entries-list ul {
-  list-style-type: none;
-  padding: 0;
-}
-.bitacora-entry {
-  background-color: #fff;
-  border: 1px solid #eee;
-  border-radius: 5px;
-  padding: 15px;
-  margin-bottom: 10px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-.entry-header {
-  font-size: 1.1em;
-  margin-bottom: 10px;
-}
-.entry-date {
-  font-size: 0.9em;
-  color: #777;
-}
-.entry-details p {
-  margin: 5px 0;
-  font-size: 0.95em;
-}
-.entry-id {
-  font-size: 0.8em;
-  color: #aaa;
-  display: block;
-  margin-top: 10px;
+/* Add any specific styles for BitacoraView if needed */
+.v-expansion-panel-title {
+  font-weight: 500;
 }
 </style>

--- a/src/components/EmbeddedBitacoraList.vue
+++ b/src/components/EmbeddedBitacoraList.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="embedded-bitacora-list">
+    <h3 v-if="title" class="text-h6 mb-2">{{ title }}</h3>
+    
+    <div v-if="isLoading" class="text-center pa-4">
+      <v-progress-circular indeterminate color="primary" size="small"></v-progress-circular>
+      <p class="text-caption">Cargando bitácora...</p>
+    </div>
+
+    <v-alert v-if="!isLoading && error" type="warning" density="compact" variant="tonal">
+      <template v-slot:prepend><v-icon size="small">mdi-alert-circle-outline</v-icon></template>
+      <span class="text-caption">Error: {{ error.message || error }}</span>
+    </v-alert>
+
+    <div v-if="!isLoading && entriesToShow.length === 0 && !error" class="text-center pa-4">
+      <p class="text-caption">No hay entradas de bitácora recientes para mostrar.</p>
+    </div>
+
+    <div v-if="!isLoading && entriesToShow.length > 0">
+      <v-list lines="one" density="compact">
+        <template v-for="(entry, index) in entriesToShow" :key="entry.id">
+          <v-list-item @click="expandedEntryId = expandedEntryId === entry.id ? null : entry.id" class="pa-0">
+            <v-row no-gutters align="center">
+              <v-col cols="auto" class="pr-2">
+                 <v-chip size="x-small" :color="estadoColor(entry.estado_ejecucion)" label>{{ entry.estado_ejecucion }}</v-chip>
+              </v-col>
+              <v-col>
+                <div class="text-subtitle-2 text-truncate">
+                  {{ getSafe(() => entry.expand.actividad_realizada.nombre, 'Actividad Desconocida') }}
+                </div>
+                <div class="text-caption grey--text text--darken-1">
+                  {{ formatDate(entry.fecha_ejecucion) }}
+                </div>
+              </v-col>
+              <v-col cols="auto">
+                <v-btn icon variant="text" size="small">
+                  <v-icon>{{ expandedEntryId === entry.id ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-list-item>
+          <v-expand-transition>
+            <div v-show="expandedEntryId === entry.id">
+              <BitacoraEntryCard :entry="entry" class="my-2 elevation-1" />
+            </div>
+          </v-expand-transition>
+          <v-divider v-if="index < entriesToShow.length - 1" class="my-1"></v-divider>
+        </template>
+      </v-list>
+    </div>
+
+    <div v-if="!isLoading && totalMatchingEntries > itemLimit && entriesToShow.length > 0" class="text-center mt-3">
+      <v-btn 
+        variant="text" 
+        color="primary" 
+        size="small"
+        @click="navigateToFullBitacora"
+      >
+        Ver Todas ({{ totalMatchingEntries }})
+        <v-icon end>mdi-arrow-right</v-icon>
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useBitacoraStore } from '@/stores/bitacoraStore';
+import BitacoraEntryCard from './BitacoraEntryCard.vue';
+
+const props = defineProps({
+  siembraId: {
+    type: String,
+    default: null,
+  },
+  actividadId: { // This refers to actividad_realizada in bitacora
+    type: String,
+    default: null,
+  },
+  itemLimit: {
+    type: Number,
+    default: 5,
+  },
+  title: {
+    type: String,
+    default: 'Bitácora Reciente'
+  }
+});
+
+const router = useRouter();
+const bitacoraStore = useBitacoraStore();
+
+const isLoading = ref(false);
+const error = ref(null);
+const allMatchingEntries = ref([]);
+const expandedEntryId = ref(null); // To expand one card at a time
+
+// Helper to safely access nested properties
+const getSafe = (fn, defaultValue = '') => {
+  try {
+    return fn() || defaultValue;
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+const fetchData = async () => {
+  isLoading.value = true;
+  error.value = null;
+  try {
+    // Ensure bitacora store is initialized (it handles its own fetching logic)
+    if(bitacoraStore.bitacoraEntries.length === 0 || !bitacoraStore.lastSync) { // Basic check
+        await bitacoraStore.init();
+    }
+
+    let entriesSource;
+    if (props.siembraId) {
+      // Assumes getEnrichedBitacoraBySiembra getter returns sorted (newest first)
+      entriesSource = bitacoraStore.getEnrichedBitacoraBySiembra(props.siembraId);
+    } else if (props.actividadId) {
+      // Assumes getEnrichedBitacoraByActividadRealizada getter returns sorted (newest first)
+      entriesSource = bitacoraStore.getEnrichedBitacoraByActividadRealizada(props.actividadId);
+    } else {
+      // Default to all entries if no specific filter, sorted by most recent
+      entriesSource = bitacoraStore.getEnrichedBitacoraEntries;
+    }
+    allMatchingEntries.value = entriesSource || [];
+
+  } catch (e) {
+    console.error('Error fetching bitacora for embedded list:', e);
+    error.value = e;
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+onMounted(fetchData);
+
+// Watch for prop changes to refetch data if necessary
+watch(() => [props.siembraId, props.actividadId], () => {
+  fetchData();
+});
+
+// Watch for changes in the store itself
+watch(() => bitacoraStore.bitacoraEntries, (newEntries) => {
+    // Re-evaluate the source based on current props when store changes
+    if (props.siembraId) {
+      allMatchingEntries.value = bitacoraStore.getEnrichedBitacoraBySiembra(props.siembraId) || [];
+    } else if (props.actividadId) {
+      allMatchingEntries.value = bitacoraStore.getEnrichedBitacoraByActividadRealizada(props.actividadId) || [];
+    } else {
+      allMatchingEntries.value = bitacoraStore.getEnrichedBitacoraEntries || [];
+    }
+}, { deep: true });
+
+
+const entriesToShow = computed(() => {
+  return allMatchingEntries.value.slice(0, props.itemLimit);
+});
+
+const totalMatchingEntries = computed(() => {
+    return allMatchingEntries.value.length;
+});
+
+function formatDate(dateString) {
+  if (!dateString) return '';
+  try {
+    const date = new Date(dateString);
+     if (isNaN(date.getTime())) return 'Fecha inválida';
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch (e) {
+    return 'Fecha inválida';
+  }
+}
+
+const estadoColor = (estado) => {
+  switch (estado?.toLowerCase()) {
+    case 'completado': return 'green-lighten-1';
+    case 'en_progreso': return 'blue-lighten-1';
+    case 'planificada': return 'orange-lighten-1';
+    case 'cancelada': return 'red-lighten-1';
+    default: return 'grey-lighten-1';
+  }
+};
+
+function navigateToFullBitacora() {
+  const query = {};
+  if (props.siembraId) query.siembraId = props.siembraId;
+  if (props.actividadId) query.actividadId = props.actividadId;
+  // Assuming your main bitacora view is at '/bitacora' route
+  // And it can accept siembraId/actividadId as query params for pre-filtering
+  router.push({ path: '/bitacora', query }); 
+}
+
+</script>
+
+<style scoped>
+.embedded-bitacora-list {
+  border: 1px solid #e0e0e0; /* Vuetify's grey.lighten-2 */
+  border-radius: 4px;
+  padding: 8px;
+}
+.v-list-item {
+  cursor: pointer;
+}
+.text-truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+</style>

--- a/src/components/SiembraWorkspace.vue
+++ b/src/components/SiembraWorkspace.vue
@@ -84,59 +84,25 @@
           </v-card-text>
         </v-card>
 
-        <!-- Bitácora 
-        <v-card class="bitacora-section" elevation="2">
-          <v-card-title class="headline d-flex justify-space-between align-center">
-            Bitácora de la Siembra
+    <!-- Nueva Bitácora Section using EmbeddedBitacoraList -->
+      <v-card class="bitacora-embedded-section mb-4" elevation="2">
+        <v-card-title class="d-flex justify-space-between align-center">
+          <span>Bitácora Reciente</span>
+          <v-btn color="primary" @click="openNewBitacoraEntryDialog" size="small">
+            <v-icon start>mdi-plus-circle-outline</v-icon>
+            Nueva Entrada
+          </v-btn>
+        </v-card-title>
+        <v-card-text>
+          <EmbeddedBitacoraList 
+            :siembraId="siembraId" 
+            title="" <!-- Title removed as it's in v-card-title -->
+            :itemLimit="5" 
+          />
+        </v-card-text>
+      </v-card>
 
-            <v-btn color="green-lighten-2" @click="openAddBitacoraDialog" icon>
-              <v-icon>mdi-plus</v-icon>
-            </v-btn>
-          </v-card-title>
-          <v-card-text>
-            <div class="d-flex flex-wrap align-center mb-0">
-              FILTRAR POR ZONAS:
-              <v-chip-group v-model="selectedZonas" column multiple>
-                <v-chip v-for="zona in zonasfiltradas" :key="zona.id" filter outlined size="small">
-                  {{ zona.nombre }}
-                </v-chip>
-              </v-chip-group>
-            </div>
-            <div class="d-flex flex-wrap align-center mb-0">
-              FILTRAR POR ACTIVIDAD:
-              <v-chip-group v-model="selectedActividades" column multiple>
-                <v-chip
-                  v-for="actividad in filteredActividades"
-                  :key="actividad.id"
-                  filter
-                  outlined
-                  size="small"
-                >
-                  {{ actividad.nombre }}
-                </v-chip>
-              </v-chip-group>
-            </div>
-            <v-data-table
-              :headers="bitacoraHeaders"
-              :items="filteredBitacora"
-              :items-per-page="itemsPerPage"
-              :footer-props="{
-                'items-per-page-options': [5, 10, 20],
-                'items-per-page-text': 'Elementos por página'
-              }"
-              class="elevation-1 tabla-compacta"
-              density="compact"
-            >
-              <template #[`item.fecha`]="{ item }">
-                {{ formatDate(item.fecha) }}
-              </template>
-              <template #[`item.actions`]="{ item }">
-                <v-icon small class="mr-2" @click="editBitacoraItem(item)"> mdi-pencil </v-icon>
-                <v-icon small @click="deleteBitacoraItem(item)"> mdi-delete </v-icon>
-              </template>
-            </v-data-table>
-          </v-card-text>
-        </v-card> -->
+      <!-- The old commented-out Bitácora section is now completely removed. -->
       </v-col>
 
       <!-- Sidebar -->
@@ -565,6 +531,17 @@
       :siembra-preseleccionada="siembraId"
       @actividad-creada="loadActividades"
     />
+
+    <!-- Dialog for BitacoraEntryForm -->
+    <v-dialog v-model="showBitacoraFormDialog" max-width="800px" persistent scrollable>
+      <BitacoraEntryForm
+        v-if="showBitacoraFormDialog"
+        :siembraIdContext="siembraId"
+        @close="showBitacoraFormDialog = false"
+        @save="handleBitacoraSave"
+      />
+    </v-dialog>
+
   </v-container>
   <v-progress-circular v-else indeterminate color="primary"></v-progress-circular>
 </template>
@@ -588,6 +565,8 @@ import { useAvatarStore } from '@/stores/avatarStore'
 import { useActividadesStore } from '@/stores/actividadesStore'
 
 import ActividadForm from '@/components/forms/ActividadForm.vue'
+import EmbeddedBitacoraList from './EmbeddedBitacoraList.vue';
+import BitacoraEntryForm from '@/components/forms/BitacoraEntryForm.vue';
 
 const route = useRoute()
 const router = useRouter()
@@ -603,9 +582,10 @@ const actividadesStore = useActividadesStore()
 
 const siembraId = ref(route.params.id)
 const siembraInfo = ref({})
-const bitacora = ref([])
+// const bitacora = ref([]) // Removed
 
 const dialogNuevaActividad = ref(false)
+const showBitacoraFormDialog = ref(false);
 
 const { zonas, tiposZonas } = storeToRefs(zonasStore)
 
@@ -650,25 +630,25 @@ const headers_actividades = [
 const expanded = ref([])
 
 const areaUnit = ref('ha')
-const itemsPerPage = ref(10)
-const selectedZonas = ref([])
-const selectedActividades = ref([])
+const itemsPerPage = ref(10) // This might be used by other tables, keeping for now unless confirmed otherwise.
+// const selectedZonas = ref([]) // Removed
+// const selectedActividades = ref([]) // Removed
 
 const editSiembraDialog = ref(false)
 const editedSiembra = ref({})
 
-const addBitacoraDialog = ref(false)
-const addZonaDialog = ref(false)
+// const addBitacoraDialog = ref(false) // Removed
+const addZonaDialog = ref(false) // Keep for ZonaForm
 
-const newBitacora = ref({
-  fecha: new Date().toISOString().split('T')[0],
-  actividad: '',
-  zonas: [],
-  descripcion: '',
-  responsable: '',
-  estado: 'planificada',
-  notas: ''
-})
+// const newBitacora = ref({ // Removed
+//   fecha: new Date().toISOString().split('T')[0],
+//   actividad: '',
+//   zonas: [],
+//   descripcion: '',
+//   responsable: '',
+//   estado: 'planificada',
+//   notas: ''
+// })
 
 const estadosSiembra = ['planificada', 'en_crecimiento', 'cosechada', 'finalizada']
 const getStatusColor = (status) => {
@@ -681,28 +661,28 @@ const getStatusColor = (status) => {
   return colors[status] || 'gray'
 }
 
-const estadosBitacora = ['planificada', 'en_progreso', 'completada', 'cancelada']
+// const estadosBitacora = ['planificada', 'en_progreso', 'completada', 'cancelada'] // Removed
 
-const bitacoraHeaders = [
-  { text: 'Fecha', value: 'fecha' },
-  { text: 'Actividad', value: 'actividad.nombre' },
-  { text: 'Zona', value: 'zona.nombre' },
-  { text: 'Responsable', value: 'responsable.name' },
-  { text: 'Estado', value: 'estado' },
-  { text: 'Acciones', value: 'actions', sortable: false }
-]
+// const bitacoraHeaders = [ // Removed
+//   { text: 'Fecha', value: 'fecha' },
+//   { text: 'Actividad', value: 'actividad.nombre' },
+//   { text: 'Zona', value: 'zona.nombre' },
+//   { text: 'Responsable', value: 'responsable.name' },
+//   { text: 'Estado', value: 'estado' },
+//   { text: 'Acciones', value: 'actions', sortable: false }
+// ]
 
-const filteredBitacora = computed(() => {
-  return bitacora.value.filter((entry) => {
-    const zonaMatch =
-      selectedZonas.value.length === 0 ||
-      entry.zonas.some((zona) => selectedZonas.value.includes(zona.id))
-    const actividadMatch =
-      selectedActividades.value.length === 0 ||
-      selectedActividades.value.includes(entry.actividad.id)
-    return zonaMatch && actividadMatch
-  })
-})
+// const filteredBitacora = computed(() => { // Removed
+//   return bitacora.value.filter((entry) => {
+//     const zonaMatch =
+//       selectedZonas.value.length === 0 ||
+//       entry.zonas.some((zona) => selectedZonas.value.includes(zona.id))
+//     const actividadMatch =
+//       selectedActividades.value.length === 0 ||
+//       selectedActividades.value.includes(entry.actividad.id)
+//     return zonaMatch && actividadMatch
+//   })
+// })
 
 const modoEdicionZona = ref(false)
 const zonaEditando = ref({
@@ -747,13 +727,13 @@ async function loadSiembraInfo() {
   }
 }
 
-async function loadBitacora() {
-  try {
-    bitacora.value = await bitacoraStore.fetchBitacoraBySiembraId(siembraId.value)
-  } catch (error) {
-    handleError(error, 'Error al cargar la bitácora')
-  }
-}
+// async function loadBitacora() { // Removed
+//   try {
+//     bitacora.value = await bitacoraStore.fetchBitacoraBySiembraId(siembraId.value)
+//   } catch (error) {
+//     handleError(error, 'Error al cargar la bitácora')
+//   }
+// }
 
 async function loadHacienda() {
   try {
@@ -785,18 +765,18 @@ function openEditDialog() {
   editSiembraDialog.value = true
 }
 
-function openAddBitacoraDialog() {
-  newBitacora.value = {
-    fecha: new Date().toISOString().split('T')[0],
-    actividad: '',
-    zonas: [],
-    descripcion: '',
-    responsable: '',
-    estado: 'planificada',
-    notas: ''
-  }
-  addBitacoraDialog.value = true
-}
+// function openAddBitacoraDialog() { // Removed
+//   newBitacora.value = {
+//     fecha: new Date().toISOString().split('T')[0],
+//     actividad: '',
+//     zonas: [],
+//     descripcion: '',
+//     responsable: '',
+//     estado: 'planificada',
+//     notas: ''
+//   }
+//   addBitacoraDialog.value = true
+// }
 
 function openAddZonaDialog() {
   modoEdicionZona.value = false
@@ -852,46 +832,46 @@ async function saveSiembraEdit() {
   }
 }
 
-async function saveBitacoraEntry() {
-  try {
-    const entry = {
-      ...newBitacora.value,
-      siembra: siembraId.value,
-      hacienda: mi_hacienda.value.id
-    }
-    await bitacoraStore.addBitacoraEntry(entry)
-    addBitacoraDialog.value = false
-    loadBitacora()
-    snackbarStore.showSnackbar('Entrada de bitácora agregada con éxito', 'success')
-  } catch (error) {
-    handleError(error, 'Error al agregar entrada de bitácora')
-  }
-}
+// async function saveBitacoraEntry() { // Removed
+//   try {
+//     const entry = {
+//       ...newBitacora.value,
+//       siembra: siembraId.value,
+//       hacienda: mi_hacienda.value.id
+//     }
+//     await bitacoraStore.addBitacoraEntry(entry)
+//     addBitacoraDialog.value = false
+//     loadBitacora()
+//     snackbarStore.showSnackbar('Entrada de bitácora agregada con éxito', 'success')
+//   } catch (error) {
+//     handleError(error, 'Error al agregar entrada de bitácora')
+//   }
+// }
 
-async function editBitacoraItem(item) {
-  try {
-    const updatedItem = await bitacoraStore.updateBitacoraEntry(item.id, item)
-    const index = bitacora.value.findIndex((entry) => entry.id === item.id)
-    if (index !== -1) {
-      bitacora.value[index] = updatedItem
-    }
-    snackbarStore.showSnackbar('Entrada de bitácora actualizada con éxito', 'success')
-  } catch (error) {
-    handleError(error, 'Error al actualizar entrada de bitácora')
-  }
-}
+// async function editBitacoraItem(item) { // Removed
+//   try {
+//     const updatedItem = await bitacoraStore.updateBitacoraEntry(item.id, item)
+//     const index = bitacora.value.findIndex((entry) => entry.id === item.id)
+//     if (index !== -1) {
+//       bitacora.value[index] = updatedItem
+//     }
+//     snackbarStore.showSnackbar('Entrada de bitácora actualizada con éxito', 'success')
+//   } catch (error) {
+//     handleError(error, 'Error al actualizar entrada de bitácora')
+//   }
+// }
 
-async function deleteBitacoraItem(item) {
-  if (confirm('¿Está seguro de que desea eliminar esta entrada de la bitácora?')) {
-    try {
-      await bitacoraStore.deleteBitacoraEntry(item.id)
-      bitacora.value = bitacora.value.filter((entry) => entry.id !== item.id)
-      snackbarStore.showSnackbar('Entrada de bitácora eliminada con éxito', 'success')
-    } catch (error) {
-      handleError(error, 'Error al eliminar entrada de bitácora')
-    }
-  }
-}
+// async function deleteBitacoraItem(item) { // Removed
+//   if (confirm('¿Está seguro de que desea eliminar esta entrada de la bitácora?')) {
+//     try {
+//       await bitacoraStore.deleteBitacoraEntry(item.id)
+//       bitacora.value = bitacora.value.filter((entry) => entry.id !== item.id)
+//       snackbarStore.showSnackbar('Entrada de bitácora eliminada con éxito', 'success')
+//     } catch (error) {
+//       handleError(error, 'Error al eliminar entrada de bitácora')
+//     }
+//   }
+// }
 
 const editActividad = (item) => {
   // Redirigir a la página de actividades con el ID de la actividad
@@ -974,9 +954,9 @@ const getAvatarUrl = (zonaId) => {
   return avatarStore.getAvatarUrl({ ...zona, type: 'zona' }, 'zonas')
 }
 
-watch([selectedZonas, selectedActividades], () => {
-  loadBitacora()
-})
+// watch([selectedZonas, selectedActividades], () => { // Removed
+//   loadBitacora()
+// })
 
 onMounted(async () => {
   try {
@@ -984,7 +964,7 @@ onMounted(async () => {
     await Promise.all([
       zonasStore.cargarZonas(),
       zonasStore.cargarTiposZonas(),
-      //   loadBitacora(),
+      // loadBitacora(), // Removed
       loadActividades(),
       loadUsuarios(),
       loadHacienda()
@@ -998,7 +978,7 @@ onMounted(async () => {
 
 const onZonaSaved = async () => {
   addZonaDialog.value = false
-  // await loadBitacora()
+  // await loadBitacora() // Removed
   snackbarStore.showSnackbar('Zona guardada exitosamente', 'success')
 }
 
@@ -1013,6 +993,17 @@ const handleAvatarUpdated = (updatedRecord) => {
 }
 
 const showAvatarDialog = ref(false)
+
+function openNewBitacoraEntryDialog() {
+  showBitacoraFormDialog.value = true;
+}
+
+async function handleBitacoraSave() {
+  showBitacoraFormDialog.value = false;
+  // EmbeddedBitacoraList should update reactively via store changes.
+  // snackbarStore.showSnackbar('Entrada de bitácora guardada.', 'success'); // Form handles its own snackbar
+}
+
 </script>
 
 <style scoped></style>

--- a/src/components/actividadesWorkspace.vue
+++ b/src/components/actividadesWorkspace.vue
@@ -225,26 +225,27 @@
           </v-col>
         </v-row>
 
-        <!-- Bitácora 
-        <v-card class="bitacora-section" elevation="2">
-          <v-card-title class="headline">Bitácora de la Actividad</v-card-title>
-          <v-card-text>
-            <v-data-table
-              :headers="bitacoraHeaders"
-              :items="filteredBitacora"
-              :items-per-page="itemsPerPage"
-              class="elevation-1"
-            >
-              <template #[`item.fecha`]="{ item }">
-                {{ formatDate(item.fecha) }}
-              </template>
-              <template #[`item.actions`]="{ item }">
-                <v-icon small @click="editBitacoraItem(item)">mdi-pencil</v-icon>
-                <v-icon small @click="deleteBitacoraItem(item)">mdi-delete</v-icon>
-              </template>
-            </v-data-table>
-          </v-card-text>
-        </v-card> -->
+      <!-- Bitácora Section using EmbeddedBitacoraList -->
+      <v-row no-gutters>
+        <v-col cols="12" class="mt-4"> <!-- Added mt-4 for spacing -->
+          <v-card class="bitacora-embedded-section" elevation="2">
+            <v-card-title class="d-flex justify-space-between align-center text-body-1">
+              <span>Bitácora Reciente</span>
+              <v-btn color="secondary" @click="openNewBitacoraEntryDialogActividad" size="small" variant="elevated">
+                <v-icon start>mdi-plus-box-outline</v-icon>
+                Nueva Entrada
+              </v-btn>
+            </v-card-title>
+            <v-card-text class="pa-2"> <!-- Adjusted padding -->
+              <EmbeddedBitacoraList 
+                :actividadId="actividadId" 
+                title="" <!-- Title removed from here as it's in v-card-title -->
+                :itemLimit="5" 
+              />
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
       </v-col>
 
       <!-- SIDEBAR  -->
@@ -690,6 +691,16 @@
       :actividadPredefinida="actividadId"
       @guardado="handleGuardado"
     />
+
+    <!-- Dialog for BitacoraEntryForm -->
+    <v-dialog v-model="showBitacoraFormDialogActividad" max-width="800px" persistent scrollable>
+      <BitacoraEntryForm
+        v-if="showBitacoraFormDialogActividad"
+        :actividadIdContext="actividadId" 
+        @close="showBitacoraFormDialogActividad = false"
+        @save="handleBitacoraSaveActividad" 
+      />
+    </v-dialog>
   </v-container>
 </template>
 
@@ -715,6 +726,8 @@ import { useProgramacionesStore } from '@/stores/programacionesStore'
 import ProgramacionPanel from '@/components/ProgramacionPanel.vue'
 import ProgramacionForm from '@/components/forms/ProgramacionForm.vue'
 import { useSnackbarStore } from '@/stores/snackbarStore'
+import EmbeddedBitacoraList from './EmbeddedBitacoraList.vue';
+import BitacoraEntryForm from '@/components/forms/BitacoraEntryForm.vue';
 
 const route = useRoute()
 const actividadesStore = useActividadesStore()
@@ -749,6 +762,8 @@ const mostrarFormProgramacion = ref(false)
 const programacionEdit = ref(null)
 
 const isLoading = ref(true)
+const showBitacoraFormDialogActividad = ref(false);
+// const itemsPerPage = ref(10); // Removed as it was likely for the old table
 
 const { user } = storeToRefs(profileStore)
 const { mi_hacienda, avatarHaciendaUrl } = storeToRefs(haciendaStore)
@@ -799,6 +814,7 @@ const getStatusMsg = (status) => {
 }
 
 /*
+// These were related to the old bitacora table and are no longer needed.
 const estadosBitacora = ['planificada', 'en_progreso', 'completada', 'cancelada']
 
 const bitacoraHeaders = [
@@ -1059,6 +1075,16 @@ const handleGuardado = async () => {
   mostrarFormProgramacion.value = false
   programacionEdit.value = null
   await cargarProgramaciones()
+}
+
+function openNewBitacoraEntryDialogActividad() {
+  showBitacoraFormDialogActividad.value = true;
+}
+
+async function handleBitacoraSaveActividad() {
+  showBitacoraFormDialogActividad.value = false;
+  // Store reactivity should update EmbeddedBitacoraList.
+  // snackbarStore.showSnackbar('Entrada de bitácora guardada.', 'success'); // Form handles its own success snackbar
 }
 </script>
 

--- a/src/components/forms/BitacoraEntryForm.vue
+++ b/src/components/forms/BitacoraEntryForm.vue
@@ -1,0 +1,395 @@
+<template>
+  <v-card>
+    <v-toolbar :color="isEditMode ? 'warning' : 'primary'" dark>
+      <v-toolbar-title>{{ formTitle }}</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn icon @click="closeDialog"><v-icon>mdi-close</v-icon></v-btn>
+    </v-toolbar>
+
+    <v-card-text>
+      <v-form ref="bitacoraFormRef">
+        <v-row dense>
+          <!-- Fecha de Ejecución -->
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="formData.fecha_ejecucion"
+              label="Fecha de Ejecución"
+              type="datetime-local"
+              :rules="[rules.required]"
+              variant="outlined"
+              density="compact"
+            ></v-text-field>
+          </v-col>
+
+          <!-- Estado de Ejecución -->
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="formData.estado_ejecucion"
+              :items="['planificada', 'en_progreso', 'completado', 'cancelada']"
+              label="Estado de Ejecución"
+              :rules="[rules.required]"
+              variant="outlined"
+              density="compact"
+            ></v-select>
+          </v-col>
+
+          <!-- Actividad Realizada -->
+          <v-col cols="12">
+            <v-autocomplete
+              v-model="formData.actividad_realizada_id"
+              :items="actividadesDisponibles"
+              item-title="nombre"
+              item-value="id"
+              label="Actividad Realizada"
+              :rules="[rules.required]"
+              variant="outlined"
+              density="compact"
+              @update:modelValue="onActividadChange"
+              :disabled="isEditMode && !!props.actividadIdContext" 
+            ></v-autocomplete>
+          </v-col>
+          
+          <!-- Siembra Asociada (Optional, might be context-driven) -->
+          <v-col cols="12" v-if="!props.siembraIdContext && selectedActividadRequiresSiembra">
+             <v-autocomplete
+              v-model="formData.siembra_asociada_id"
+              :items="siembrasDisponibles"
+              item-title="nombre"
+              item-value="id"
+              label="Siembra Asociada (si aplica)"
+              variant="outlined"
+              density="compact"
+              clearable
+            ></v-autocomplete>
+          </v-col>
+
+
+          <!-- Notas -->
+          <v-col cols="12">
+            <v-textarea
+              v-model="formData.notas"
+              label="Notas Adicionales"
+              variant="outlined"
+              density="compact"
+              rows="3"
+            ></v-textarea>
+          </v-col>
+
+          <!-- Dynamic Metricas Section -->
+          <v-col cols="12" v-if="selectedActividadDetalles && metricasParaFormulario.length > 0">
+            <v-divider class="my-3"></v-divider>
+            <h3 class="text-subtitle-1 mb-2">Métricas de la Actividad</h3>
+            <v-row dense v-for="metrica in metricasParaFormulario" :key="metrica.key">
+              <v-col cols="12">
+                <template v-if="metrica.tipo === 'select'">
+                  <v-select
+                    v-model="formData.metricas_values[metrica.key]"
+                    :items="metrica.opciones"
+                    :label="metrica.descripcion || metrica.key.replace(/_/g, ' ')"
+                    variant="outlined"
+                    density="compact"
+                    :rules="metrica.requerido ? [rules.required] : []"
+                  ></v-select>
+                </template>
+                <template v-else-if="metrica.tipo === 'boolean'">
+                   <v-checkbox
+                    v-model="formData.metricas_values[metrica.key]"
+                    :label="metrica.descripcion || metrica.key.replace(/_/g, ' ')"
+                    density="compact"
+                  ></v-checkbox>
+                </template>
+                <template v-else-if="metrica.tipo === 'number'">
+                  <v-text-field
+                    v-model.number="formData.metricas_values[metrica.key]"
+                    :label="metrica.descripcion || metrica.key.replace(/_/g, ' ')"
+                    type="number"
+                    variant="outlined"
+                    density="compact"
+                    :rules="metrica.requerido ? [rules.required] : []"
+                  ></v-text-field>
+                </template>
+                <template v-else> <!-- Default to string/text -->
+                  <v-text-field
+                    v-model="formData.metricas_values[metrica.key]"
+                    :label="metrica.descripcion || metrica.key.replace(/_/g, ' ')"
+                    variant="outlined"
+                    density="compact"
+                    :rules="metrica.requerido ? [rules.required] : []"
+                  ></v-text-field>
+                </template>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
+
+    <v-card-actions class="pa-4">
+      <v-spacer></v-spacer>
+      <v-btn variant="text" @click="closeDialog">Cancelar</v-btn>
+      <v-btn color="primary" variant="flat" @click="submitForm" :loading="isSubmitting">
+        {{ isEditMode ? 'Guardar Cambios' : 'Crear Entrada' }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, watch, computed } from 'vue';
+import { useActividadesStore } from '@/stores/actividadesStore';
+import { useSiembrasStore } from '@/stores/siembrasStore';
+import { useBitacoraStore } from '@/stores/bitacoraStore';
+import { useSnackbarStore } from '@/stores/snackbarStore';
+import { handleError } from '@/utils/errorHandler';
+
+const props = defineProps({
+  entryToEdit: {
+    type: Object,
+    default: null,
+  },
+  siembraIdContext: { // To filter/suggest activities or auto-assign siembra
+    type: String,
+    default: null,
+  },
+  actividadIdContext: { // To pre-select activity
+    type: String,
+    default: null,
+  },
+});
+
+const emit = defineEmits(['close', 'save']);
+
+const actividadesStore = useActividadesStore();
+const siembrasStore = useSiembrasStore();
+const bitacoraStore = useBitacoraStore();
+const snackbarStore = useSnackbarStore();
+
+const bitacoraFormRef = ref(null);
+const isSubmitting = ref(false);
+
+const actividadesDisponibles = ref([]);
+const siembrasDisponibles = ref([]); // For optional siembra_asociada selection
+const selectedActividadDetalles = ref(null); // To store full details of selected actividad
+
+const defaultFormData = () => ({
+  fecha_ejecucion: new Date().toISOString().substring(0, 16), // YYYY-MM-DDTHH:mm
+  actividad_realizada_id: props.actividadIdContext || null,
+  estado_ejecucion: 'completado',
+  notas: '',
+  siembra_asociada_id: props.siembraIdContext || null, // Auto-assign if context provided
+  metricas_values: {}, // Holds values for dynamic metric fields
+});
+
+const formData = reactive(defaultFormData());
+
+const rules = {
+  required: value => !!value || 'Este campo es requerido.',
+};
+
+const isEditMode = computed(() => !!props.entryToEdit);
+const formTitle = computed(() => isEditMode.value ? 'Editar Entrada de Bitácora' : 'Nueva Entrada de Bitácora');
+
+const selectedActividadRequiresSiembra = computed(() => {
+    // Logic to determine if the selected actividad type typically requires a siembra.
+    // This might involve checking a property on selectedActividadDetalles.expand.tipo_actividades
+    // For now, let's assume some activities might not be directly tied to a siembra (e.g., general maintenance)
+    // and allow manual selection if no siembraIdContext is provided.
+    if (!selectedActividadDetalles.value) return false;
+    // Example: if tipo_actividad has a flag like 'requires_siembra'
+    // return selectedActividadDetalles.value.expand?.tipo_actividades?.requires_siembra === true;
+    return true; // Default to true for now, show siembra selector if no context
+});
+
+
+onMounted(async () => {
+  try {
+    // Fetch actividades
+    if (actividadesStore.actividades.length === 0) {
+      await actividadesStore.cargarActividades(); // Ensure this method loads all necessary activities
+    }
+    // Filter activities if siembraIdContext is provided (optional)
+    if (props.siembraIdContext) {
+        actividadesDisponibles.value = actividadesStore.actividades.filter(
+            act => Array.isArray(act.siembras) && act.siembras.includes(props.siembraIdContext)
+        );
+    } else {
+        actividadesDisponibles.value = actividadesStore.actividades;
+    }
+    
+    // Fetch siembras for optional manual selection
+    if (siembrasStore.siembras.length === 0) {
+        await siembrasStore.cargarSiembras();
+    }
+    siembrasDisponibles.value = siembrasStore.siembras;
+
+    if (props.actividadIdContext) {
+      await loadActividadDetails(props.actividadIdContext);
+    }
+
+    if (isEditMode.value && props.entryToEdit) {
+      populateFormForEdit();
+    }
+
+  } catch (error) {
+    handleError(error, 'Error inicializando formulario de bitácora');
+    snackbarStore.showSnackbar('Error cargando datos para el formulario.', 'error');
+  }
+});
+
+watch(() => props.entryToEdit, (newVal) => {
+  if (newVal && isEditMode.value) {
+    populateFormForEdit();
+  } else if (!newVal) {
+    Object.assign(formData, defaultFormData());
+    selectedActividadDetalles.value = null;
+  }
+}, { immediate: true });
+
+watch(() => props.actividadIdContext, async (newVal) => {
+    if (newVal && !isEditMode.value) { // Only auto-select on create if context changes
+        formData.actividad_realizada_id = newVal;
+        await loadActividadDetails(newVal);
+    }
+});
+watch(() => props.siembraIdContext, (newVal) => {
+    if (newVal && !isEditMode.value) {
+        formData.siembra_asociada_id = newVal;
+         // Optionally re-filter actividadesDisponibles if not already done by onMounted logic
+    }
+});
+
+
+async function loadActividadDetails(actividadId) {
+  if (!actividadId) {
+    selectedActividadDetalles.value = null;
+    formData.metricas_values = {}; // Clear metric values
+    return;
+  }
+  try {
+    // Fetch full actividad details including its 'metricas' definition and expanded 'tipo_actividades' (for formato_reporte)
+    // actividadesStore should have a method to fetch a single, fully expanded activity.
+    const actividad = await actividadesStore.fetchActividadById(actividadId, { expand: 'tipo_actividades' }); // Pass expand options
+    selectedActividadDetalles.value = actividad;
+    initializeMetricasValues();
+  } catch (error) {
+    handleError(error, `Error cargando detalles de actividad ${actividadId}`);
+    selectedActividadDetalles.value = null;
+  }
+}
+
+function initializeMetricasValues() {
+  formData.metricas_values = {};
+  if (selectedActividadDetalles.value?.metricas) {
+    for (const key in selectedActividadDetalles.value.metricas) {
+      const metricaDef = selectedActividadDetalles.value.metricas[key];
+      // Set default value based on type or definition
+      formData.metricas_values[key] = metricaDef.defaultValue !== undefined ? metricaDef.defaultValue : (metricaDef.tipo === 'boolean' ? false : null);
+    }
+  }
+}
+
+async function onActividadChange(actividadId) {
+  await loadActividadDetails(actividadId);
+}
+
+function populateFormForEdit() {
+  if (!props.entryToEdit) return;
+  const entry = props.entryToEdit;
+  formData.fecha_ejecucion = entry.fecha_ejecucion ? new Date(entry.fecha_ejecucion).toISOString().substring(0, 16) : new Date().toISOString().substring(0, 16);
+  formData.actividad_realizada_id = typeof entry.actividad_realizada === 'string' ? entry.actividad_realizada : entry.expand?.actividad_realizada?.id;
+  formData.estado_ejecucion = entry.estado_ejecucion || 'completado';
+  formData.notas = entry.notas || '';
+  formData.siembra_asociada_id = typeof entry.siembra_asociada === 'string' ? entry.siembra_asociada : entry.expand?.siembra_asociada?.id;
+  
+  // Load actividad details for edit mode to ensure metric definitions are available
+  if (formData.actividad_realizada_id) {
+    loadActividadDetails(formData.actividad_realizada_id).then(() => {
+      // Once details (and thus metric definitions) are loaded, populate metricas_values
+      if (entry.metricas && typeof entry.metricas === 'object') {
+        formData.metricas_values = { ...entry.metricas };
+      } else {
+        formData.metricas_values = {}; // Initialize if no metrics were stored
+      }
+    });
+  } else {
+     formData.metricas_values = {};
+  }
+}
+
+const metricasParaFormulario = computed(() => {
+  if (!selectedActividadDetalles.value) return [];
+
+  const activityMetrics = selectedActividadDetalles.value.metricas || {}; // Customized metrics for the activity
+  const tipoActividadFormato = selectedActividadDetalles.value.expand?.tipo_actividades?.formato_reporte?.columnas || [];
+  
+  // Use formato_reporte from tipo_actividad to determine which metrics to show and their order/labels
+  return tipoActividadFormato.map(col => {
+    const metricaKey = col.metrica;
+    if (metricaKey && activityMetrics[metricaKey]) { // Ensure the metric key from format is in activity's defined metrics
+      return {
+        key: metricaKey,
+        descripcion: col.nombre, // Use nombre from formato_reporte as label
+        tipo: activityMetrics[metricaKey].tipo,
+        opciones: activityMetrics[metricaKey].opciones || [],
+        requerido: activityMetrics[metricaKey].requerido || false, // Assuming 'requerido' field in metric definition
+      };
+    } else if (col.tipo === 'text' && !col.metrica) { // For direct fields like "Observaciones" in formato_reporte
+        return {
+            key: col.nombre.toLowerCase().replace(/\s+/g, '_'), // Generate a key
+            descripcion: col.nombre,
+            tipo: 'textarea', // Or 'string'
+            requerido: false
+        };
+    }
+    return null;
+  }).filter(m => m !== null);
+});
+
+async function submitForm() {
+  const { valid } = await bitacoraFormRef.value.validate();
+  if (!valid) {
+    snackbarStore.showSnackbar('Por favor, corrija los errores en el formulario.', 'error');
+    return;
+  }
+
+  isSubmitting.value = true;
+  try {
+    const dataToSubmit = {
+      fecha_ejecucion: new Date(formData.fecha_ejecucion).toISOString(),
+      actividad_realizada: formData.actividad_realizada_id,
+      estado_ejecucion: formData.estado_ejecucion,
+      notas: formData.notas,
+      siembra_asociada: formData.siembra_asociada_id || null, // Ensure null if empty
+      metricas: { ...formData.metricas_values }, // Actual recorded values
+      // user_responsable will be set by bitacoraStore.crearBitacoraEntry if not provided
+    };
+
+    if (isEditMode.value) {
+      await bitacoraStore.updateBitacoraEntry(props.entryToEdit.id, dataToSubmit);
+      snackbarStore.showSnackbar('Entrada de bitácora actualizada con éxito.', 'success');
+    } else {
+      await bitacoraStore.crearBitacoraEntry(dataToSubmit);
+      snackbarStore.showSnackbar('Nueva entrada de bitácora creada con éxito.', 'success');
+    }
+    emit('save');
+    closeDialog();
+  } catch (error) {
+    handleError(error, `Error ${isEditMode.value ? 'actualizando' : 'creando'} entrada de bitácora`);
+    // snackbar is shown by handleError
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function closeDialog() {
+  Object.assign(formData, defaultFormData()); // Reset form
+  selectedActividadDetalles.value = null;
+  bitacoraFormRef.value?.resetValidation();
+  emit('close');
+}
+
+</script>
+
+<style scoped>
+/* Add any specific styles for the form if needed */
+</style>

--- a/src/stores/actividadesStore.js
+++ b/src/stores/actividadesStore.js
@@ -427,6 +427,51 @@ export const useActividadesStore = defineStore('actividades', {
       const localTiposActividades = syncStore.loadFromLocalStorage('tiposActividades');
       this.tiposActividades = localTiposActividades || [];
       console.log('[ACT_STORE] Initialized from localStorage. Actividades:', this.actividades.length, 'Tipos:', this.tiposActividades.length);
+    },
+
+    // Standard sync methods
+    applySyncedCreate(tempId, realItem) {
+      const syncStore = useSyncStore();
+      console.log(`[ACTIVIDADES_STORE] Applying synced create: tempId ${tempId} -> realId ${realItem.id}`);
+      const index = this.actividades.findIndex(a => a.id === tempId && a._isTemp);
+      if (index !== -1) {
+        this.actividades[index] = { ...realItem, _isTemp: false };
+      } else {
+        if (!this.actividades.some(a => a.id === realItem.id)) {
+            this.actividades.unshift({ ...realItem, _isTemp: false }); 
+            console.log('[ACTIVIDADES_STORE] Synced item added as new (was not found by tempId).');
+        } else {
+            console.log('[ACTIVIDADES_STORE] Synced item already exists by realId.');
+        }
+      }
+      syncStore.saveToLocalStorage('actividades', this.actividades);
+      console.log('[ACTIVIDADES_STORE] Synced create applied, localStorage updated.');
+    },
+
+    applySyncedUpdate(id, updatedItemData) {
+      const syncStore = useSyncStore();
+      console.log(`[ACTIVIDADES_STORE] Applying synced update for id: ${id}`);
+      const index = this.actividades.findIndex(a => a.id === id);
+      if (index !== -1) {
+        this.actividades[index] = { ...this.actividades[index], ...updatedItemData, _isTemp: false };
+        syncStore.saveToLocalStorage('actividades', this.actividades);
+        console.log('[ACTIVIDADES_STORE] Synced update applied, localStorage updated.');
+      } else {
+         console.warn(`[ACTIVIDADES_STORE] Could not find item with id ${id} to apply update.`);
+      }
+    },
+
+    applySyncedDelete(id) {
+      const syncStore = useSyncStore();
+      console.log(`[ACTIVIDADES_STORE] Applying synced delete for id: ${id}`);
+      const initialLength = this.actividades.length;
+      this.actividades = this.actividades.filter(a => a.id !== id);
+      if (this.actividades.length < initialLength) {
+        syncStore.saveToLocalStorage('actividades', this.actividades);
+        console.log('[ACTIVIDADES_STORE] Synced delete applied, localStorage updated.');
+      } else {
+        console.warn(`[ACTIVIDADES_STORE] Could not find item with id ${id} to apply delete.`);
+      }
     }
   }
 })

--- a/src/stores/bitacoraStore.js
+++ b/src/stores/bitacoraStore.js
@@ -1,76 +1,280 @@
-import { defineStore } from 'pinia'
-
-import { pb } from '@/utils/pocketbase'
-import { handleError } from '@/utils/errorHandler'
+import { defineStore } from 'pinia';
+import { pb } from '@/utils/pocketbase';
+import { handleError } from '@/utils/errorHandler';
+import { useSyncStore } from './syncStore'; // For queueOperation and generateTempId
+import { useAuthStore } from './authStore'; // For current user ID
+import { useHaciendaStore } from './haciendaStore'; // For current hacienda ID
 
 export const useBitacoraStore = defineStore('bitacora', {
   state: () => ({
     bitacoraEntries: [],
-    isLoading: false
+    isLoading: false,
+    lastSync: null, // Timestamp of last successful fetch from server
   }),
 
+  getters: {
+    // Example getter: Get entries by programacion_origen
+    getBitacoraByProgramacion: (state) => (programacionId) => {
+      return state.bitacoraEntries.filter(entry => entry.programacion_origen === programacionId);
+    },
+    // Example getter: Get entries by siembra_asociada
+    getBitacoraBySiembra: (state) => (siembraId) => {
+      return state.bitacoraEntries.filter(entry => entry.siembra_asociada === siembraId);
+    },
+    // Get all entries sorted by creation date (newest first)
+    sortedEntries: (state) => {
+      return [...state.bitacoraEntries].sort((a, b) => new Date(b.created) - new Date(a.created));
+    }
+  },
+
   actions: {
-    async fetchBitacoraBySiembraId(siembraId) {
-      this.isLoading = true
-      try {
-        const records = await pb.collection('bitacora').getList(1, 50, {
-          filter: `siembra="${siembraId}"`,
-          sort: '-fecha',
-          expand: 'actividad,zona,responsable'
-        })
-        this.bitacoraEntries = records.items
-        return this.bitacoraEntries
-      } catch (error) {
-        handleError(error, 'Error al cargar la bitácora')
-        return []
-      } finally {
-        this.isLoading = false
-      }
-    },
+    // Initialize store: load from localStorage, then fetch if online
+    async init() {
+      console.log('[BITACORA_STORE] Initializing...');
+      const syncStore = useSyncStore();
+      const haciendaStore = useHaciendaStore();
 
-    async addBitacoraEntry(entry) {
-      this.isLoading = true
-      try {
-        const record = await pb.collection('bitacora').create(entry)
-        this.bitacoraEntries.unshift(record)
-        return record
-      } catch (error) {
-        handleError(error, 'Error al agregar entrada a la bitácora')
-        return null
-      } finally {
-        this.isLoading = false
+      const localData = syncStore.loadFromLocalStorage('bitacoraEntries');
+      if (localData) {
+        this.bitacoraEntries = localData;
+        console.log('[BITACORA_STORE] Loaded from localStorage:', this.bitacoraEntries.length, 'entries.');
       }
-    },
 
-    async updateBitacoraEntry(id, updates) {
-      this.isLoading = true
-      try {
-        const record = await pb.collection('bitacora').update(id, updates)
-        const index = this.bitacoraEntries.findIndex((entry) => entry.id === id)
-        if (index !== -1) {
-          this.bitacoraEntries[index] = { ...this.bitacoraEntries[index], ...record }
+      if (syncStore.isOnline && haciendaStore.mi_hacienda?.id) {
+        try {
+          await this.cargarBitacoraEntries(haciendaStore.mi_hacienda.id);
+        } catch (error) {
+          // handleError is likely called within cargarBitacoraEntries
+          console.error('[BITACORA_STORE] Error during initial fetch:', error);
         }
-        return record
+      }
+      console.log('[BITACORA_STORE] Initialization complete.');
+    },
+
+    // Fetch entries from PocketBase for the current hacienda
+    async cargarBitacoraEntries(haciendaId) {
+      if (!haciendaId) {
+        console.warn('[BITACORA_STORE] No haciendaId provided to cargarBitacoraEntries.');
+        return;
+      }
+      console.log(`[BITACORA_STORE] Fetching entries for hacienda: ${haciendaId}`);
+      this.isLoading = true;
+      try {
+        const records = await pb.collection('bitacora').getFullList({
+          filter: `hacienda="${haciendaId}"`,
+          sort: '-created', // newest first
+          // Consider expanding relations if needed directly on load, e.g., expand: 'actividad_realizada,siembra_asociada'
+        });
+        this.bitacoraEntries = records.map(entry => ({...entry, _isTemp: false })); // Ensure no old temp flags
+        this.lastSync = Date.now();
+        useSyncStore().saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+        console.log('[BITACORA_STORE] Fetched and saved to localStorage:', this.bitacoraEntries.length, 'entries.');
       } catch (error) {
-        handleError(error, 'Error al actualizar entrada de la bitácora')
-        return null
+        handleError(error, 'Error cargando entradas de bitácora desde PocketBase');
       } finally {
-        this.isLoading = false
+        this.isLoading = false;
       }
     },
 
-    async deleteBitacoraEntry(id) {
-      this.isLoading = true
-      try {
-        await pb.collection('bitacora').delete(id)
-        this.bitacoraEntries = this.bitacoraEntries.filter((entry) => entry.id !== id)
-        return true
-      } catch (error) {
-        handleError(error, 'Error al eliminar entrada de la bitácora')
-        return false
-      } finally {
-        this.isLoading = false
+    // Create a new bitacora entry
+    async crearBitacoraEntry(entryData) {
+      console.log('[BITACORA_STORE] Attempting to create bitacora entry:', entryData);
+      const syncStore = useSyncStore();
+      const authStore = useAuthStore();
+      const haciendaStore = useHaciendaStore();
+
+      const fullEntryData = {
+        ...entryData,
+        hacienda: entryData.hacienda || haciendaStore.mi_hacienda?.id,
+        user_responsable: entryData.user_responsable || authStore.user?.id,
+        // Ensure all required fields for PB collection are present
+      };
+
+      // Validate essential fields (adjust as per your PB collection's requirements)
+      if (!fullEntryData.hacienda || !fullEntryData.programacion_origen || !fullEntryData.actividad_realizada || !fullEntryData.fecha_ejecucion) {
+          console.error('[BITACORA_STORE] Missing essential data for bitacora entry:', fullEntryData);
+          handleError(new Error('Datos incompletos para la entrada de bitácora.'), 'Error creando entrada de bitácora');
+          return null; // Or throw error
       }
+
+      if (!syncStore.isOnline) {
+        console.log('[BITACORA_STORE] Offline mode: Creating temporary entry.');
+        const tempId = syncStore.generateTempId(); // Use syncStore's method
+        const tempEntry = {
+          ...fullEntryData,
+          id: tempId,
+          created: new Date().toISOString(), // Simulate PB fields
+          updated: new Date().toISOString(),
+          _isTemp: true,
+        };
+        this.bitacoraEntries.unshift(tempEntry); // Add to start of array
+        syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+
+        await syncStore.queueOperation({
+          type: 'create',
+          collection: 'bitacora', // Collection name in PocketBase
+          data: fullEntryData, // Data without tempId for PB
+          tempId: tempId,
+        });
+        console.log('[BITACORA_STORE] Temporary entry created and queued:', tempEntry);
+        return tempEntry;
+      }
+
+      console.log('[BITACORA_STORE] Online mode: Creating entry directly on PocketBase.');
+      this.isLoading = true;
+      try {
+        // Data sent to PB should not contain tempId or _isTemp
+        const record = await pb.collection('bitacora').create(fullEntryData);
+        const newEntry = {...record, _isTemp: false };
+        this.bitacoraEntries.unshift(newEntry);
+        syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+        console.log('[BITACORA_STORE] Entry created on PocketBase and added to store:', newEntry);
+        return newEntry;
+      } catch (error) {
+        handleError(error, 'Error creando entrada de bitácora en PocketBase');
+        return null; // Or throw error
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    // Apply a synced creation from syncStore
+    applySyncedCreate(tempId, realItem) {
+      console.log(`[BITACORA_STORE] Applying synced create: tempId ${tempId} -> realId ${realItem.id}`);
+      const index = this.bitacoraEntries.findIndex(entry => entry.id === tempId && entry._isTemp);
+      if (index !== -1) {
+        this.bitacoraEntries[index] = { ...realItem, _isTemp: false };
+        useSyncStore().saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+        console.log('[BITACORA_STORE] Synced create applied.');
+      } else {
+        // If not found by tempId (e.g., page reloaded before sync completed but after queue processed),
+        // add if it's not already present by realId (to avoid duplicates)
+        if (!this.bitacoraEntries.some(entry => entry.id === realItem.id)) {
+            this.bitacoraEntries.unshift({ ...realItem, _isTemp: false });
+            useSyncStore().saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+            console.log('[BITACORA_STORE] Synced item added as new (was not found by tempId).');
+        } else {
+            console.log('[BITACORA_STORE] Synced item already exists by realId.');
+        }
+      }
+    },
+
+    // Apply a synced update from syncStore
+    applySyncedUpdate(id, updatedItemData) {
+      console.log(`[BITACORA_STORE] Applying synced update for id: ${id}`);
+      const index = this.bitacoraEntries.findIndex(entry => entry.id === id);
+      if (index !== -1) {
+        // Merge carefully: updatedItemData might be partial
+        this.bitacoraEntries[index] = { ...this.bitacoraEntries[index], ...updatedItemData, _isTemp: false };
+        useSyncStore().saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+        console.log('[BITACORA_STORE] Synced update applied.');
+      } else {
+         console.warn(`[BITACORA_STORE] Could not find item with id ${id} to apply update.`);
+         // Optionally, fetch it if critical, or add if it's a new item not yet in local store
+         // For now, just log.
+      }
+    },
+
+    // Apply a synced delete from syncStore
+    applySyncedDelete(id) {
+      console.log(`[BITACORA_STORE] Applying synced delete for id: ${id}`);
+      const initialLength = this.bitacoraEntries.length;
+      this.bitacoraEntries = this.bitacoraEntries.filter(entry => entry.id !== id);
+      if (this.bitacoraEntries.length < initialLength) {
+        useSyncStore().saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+        console.log('[BITACORA_STORE] Synced delete applied.');
+      } else {
+        console.warn(`[BITACORA_STORE] Could not find item with id ${id} to apply delete.`);
+      }
+    },
+    
+    // Placeholder for direct online update if needed, with offline queuing
+    async updateBitacoraEntry(id, dataToUpdate) {
+        const syncStore = useSyncStore();
+        console.log(`[BITACORA_STORE] Attempting to update entry ${id}:`, dataToUpdate);
+
+        if (!syncStore.isOnline) {
+            console.log('[BITACORA_STORE] Offline mode: Queuing update.');
+            // Update locally first
+            const index = this.bitacoraEntries.findIndex(entry => entry.id === id);
+            if (index !== -1) {
+                this.bitacoraEntries[index] = { ...this.bitacoraEntries[index], ...dataToUpdate, updated: new Date().toISOString() };
+                syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+            } else {
+                 console.warn(`[BITACORA_STORE] Cannot update locally: item with id ${id} not found.`);
+                 // Do not queue if item doesn't exist locally
+                 return null;
+            }
+            
+            await syncStore.queueOperation({
+                type: 'update',
+                collection: 'bitacora',
+                id: id, // Real ID, assuming it's a synced item or tempId if not yet synced (though update usually implies synced)
+                data: dataToUpdate,
+            });
+            return this.bitacoraEntries[index];
+        }
+
+        console.log('[BITACORA_STORE] Online mode: Updating entry directly on PocketBase.');
+        this.isLoading = true;
+        try {
+            const record = await pb.collection('bitacora').update(id, dataToUpdate);
+            const updatedEntry = { ...record, _isTemp: false };
+            const index = this.bitacoraEntries.findIndex(entry => entry.id === id);
+            if (index !== -1) {
+                this.bitacoraEntries[index] = updatedEntry;
+            } else {
+                this.bitacoraEntries.unshift(updatedEntry); // Add if not found (should ideally exist)
+            }
+            syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+            return updatedEntry;
+        } catch (error) {
+            handleError(error, `Error actualizando entrada de bitácora ${id} en PocketBase`);
+            return null;
+        } finally {
+            this.isLoading = false;
+        }
+    },
+
+    // Placeholder for direct online delete if needed, with offline queuing
+    async deleteBitacoraEntry(id) {
+        const syncStore = useSyncStore();
+        console.log(`[BITACORA_STORE] Attempting to delete entry ${id}`);
+
+        if (!syncStore.isOnline) {
+            console.log('[BITACORA_STORE] Offline mode: Queuing delete.');
+            // Remove locally first
+            const initialLength = this.bitacoraEntries.length;
+            this.bitacoraEntries = this.bitacoraEntries.filter(entry => entry.id !== id);
+            if (this.bitacoraEntries.length < initialLength) {
+                syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+            } else {
+                console.warn(`[BITACORA_STORE] Cannot delete locally: item with id ${id} not found.`);
+                // Do not queue if item doesn't exist locally
+                return false;
+            }
+
+            await syncStore.queueOperation({
+                type: 'delete',
+                collection: 'bitacora',
+                id: id,
+            });
+            return true;
+        }
+
+        console.log('[BITACORA_STORE] Online mode: Deleting entry directly on PocketBase.');
+        this.isLoading = true;
+        try {
+            await pb.collection('bitacora').delete(id);
+            this.bitacoraEntries = this.bitacoraEntries.filter(entry => entry.id !== id);
+            syncStore.saveToLocalStorage('bitacoraEntries', this.bitacoraEntries);
+            return true;
+        } catch (error) {
+            handleError(error, `Error eliminando entrada de bitácora ${id} en PocketBase`);
+            return false;
+        } finally {
+            this.isLoading = false;
+        }
     }
   }
-})
+});

--- a/src/stores/programacionesStore.js
+++ b/src/stores/programacionesStore.js
@@ -552,6 +552,52 @@ export const useProgramacionesStore = defineStore('programaciones', {
         id,
         this.programaciones
       )
+    },
+
+    // Standard sync methods
+    applySyncedCreate(tempId, realItem) {
+      const syncStore = useSyncStore();
+      console.log(`[PROGRAMACIONES_STORE] Applying synced create: tempId ${tempId} -> realId ${realItem.id}`);
+      const index = this.programaciones.findIndex(p => p.id === tempId && p._isTemp);
+      if (index !== -1) {
+        this.programaciones[index] = { ...realItem, _isTemp: false };
+      } else {
+        // If not found by tempId (e.g., page reloaded), add if it's not already present by realId
+        if (!this.programaciones.some(p => p.id === realItem.id)) {
+            this.programaciones.unshift({ ...realItem, _isTemp: false }); // Or push, unshift to show newest first
+            console.log('[PROGRAMACIONES_STORE] Synced item added as new (was not found by tempId).');
+        } else {
+            console.log('[PROGRAMACIONES_STORE] Synced item already exists by realId.');
+        }
+      }
+      syncStore.saveToLocalStorage('programaciones', this.programaciones);
+      console.log('[PROGRAMACIONES_STORE] Synced create applied, localStorage updated.');
+    },
+
+    applySyncedUpdate(id, updatedItemData) {
+      const syncStore = useSyncStore();
+      console.log(`[PROGRAMACIONES_STORE] Applying synced update for id: ${id}`);
+      const index = this.programaciones.findIndex(p => p.id === id);
+      if (index !== -1) {
+        this.programaciones[index] = { ...this.programaciones[index], ...updatedItemData, _isTemp: false };
+        syncStore.saveToLocalStorage('programaciones', this.programaciones);
+        console.log('[PROGRAMACIONES_STORE] Synced update applied, localStorage updated.');
+      } else {
+         console.warn(`[PROGRAMACIONES_STORE] Could not find item with id ${id} to apply update.`);
+      }
+    },
+
+    applySyncedDelete(id) {
+      const syncStore = useSyncStore();
+      console.log(`[PROGRAMACIONES_STORE] Applying synced delete for id: ${id}`);
+      const initialLength = this.programaciones.length;
+      this.programaciones = this.programaciones.filter(p => p.id !== id);
+      if (this.programaciones.length < initialLength) {
+        syncStore.saveToLocalStorage('programaciones', this.programaciones);
+        console.log('[PROGRAMACIONES_STORE] Synced delete applied, localStorage updated.');
+      } else {
+        console.warn(`[PROGRAMACIONES_STORE] Could not find item with id ${id} to apply delete.`);
+      }
     }
   }
 })

--- a/src/stores/siembrasStore.js
+++ b/src/stores/siembrasStore.js
@@ -267,6 +267,51 @@ export const useSiembrasStore = defineStore('siembras', {
       const localSiembras = syncStore.loadFromLocalStorage('siembras');
       this.siembras = localSiembras || [];
       console.log('[SIEMBRAS_STORE] Initialized from localStorage. Siembras:', this.siembras.length);
+    },
+
+    // Standard sync methods
+    applySyncedCreate(tempId, realItem) {
+      const syncStore = useSyncStore();
+      console.log(`[SIEMBRAS_STORE] Applying synced create: tempId ${tempId} -> realId ${realItem.id}`);
+      const index = this.siembras.findIndex(s => s.id === tempId && s._isTemp);
+      if (index !== -1) {
+        this.siembras[index] = { ...realItem, _isTemp: false };
+      } else {
+        if (!this.siembras.some(s => s.id === realItem.id)) {
+            this.siembras.unshift({ ...realItem, _isTemp: false }); 
+            console.log('[SIEMBRAS_STORE] Synced item added as new (was not found by tempId).');
+        } else {
+            console.log('[SIEMBRAS_STORE] Synced item already exists by realId.');
+        }
+      }
+      syncStore.saveToLocalStorage('siembras', this.siembras);
+      console.log('[SIEMBRAS_STORE] Synced create applied, localStorage updated.');
+    },
+
+    applySyncedUpdate(id, updatedItemData) {
+      const syncStore = useSyncStore();
+      console.log(`[SIEMBRAS_STORE] Applying synced update for id: ${id}`);
+      const index = this.siembras.findIndex(s => s.id === id);
+      if (index !== -1) {
+        this.siembras[index] = { ...this.siembras[index], ...updatedItemData, _isTemp: false };
+        syncStore.saveToLocalStorage('siembras', this.siembras);
+        console.log('[SIEMBRAS_STORE] Synced update applied, localStorage updated.');
+      } else {
+         console.warn(`[SIEMBRAS_STORE] Could not find item with id ${id} to apply update.`);
+      }
+    },
+
+    applySyncedDelete(id) {
+      const syncStore = useSyncStore();
+      console.log(`[SIEMBRAS_STORE] Applying synced delete for id: ${id}`);
+      const initialLength = this.siembras.length;
+      this.siembras = this.siembras.filter(s => s.id !== id);
+      if (this.siembras.length < initialLength) {
+        syncStore.saveToLocalStorage('siembras', this.siembras);
+        console.log('[SIEMBRAS_STORE] Synced delete applied, localStorage updated.');
+      } else {
+        console.warn(`[SIEMBRAS_STORE] Could not find item with id ${id} to apply delete.`);
+      }
     }
   }
 })

--- a/src/stores/zonasStore.js
+++ b/src/stores/zonasStore.js
@@ -366,6 +366,51 @@ export const useZonasStore = defineStore('zonas', {
       const localTiposZonas = syncStore.loadFromLocalStorage('tiposZonas');
       this.tiposZonas = localTiposZonas || [];
       console.log('[ZONAS_STORE] Initialized from localStorage. Zonas:', this.zonas.length, 'Tipos:', this.tiposZonas.length);
+    },
+
+    // Standard sync methods
+    applySyncedCreate(tempId, realItem) {
+      const syncStore = useSyncStore();
+      console.log(`[ZONAS_STORE] Applying synced create: tempId ${tempId} -> realId ${realItem.id}`);
+      const index = this.zonas.findIndex(z => z.id === tempId && z._isTemp);
+      if (index !== -1) {
+        this.zonas[index] = { ...realItem, _isTemp: false };
+      } else {
+        if (!this.zonas.some(z => z.id === realItem.id)) {
+            this.zonas.unshift({ ...realItem, _isTemp: false }); 
+            console.log('[ZONAS_STORE] Synced item added as new (was not found by tempId).');
+        } else {
+            console.log('[ZONAS_STORE] Synced item already exists by realId.');
+        }
+      }
+      syncStore.saveToLocalStorage('zonas', this.zonas);
+      console.log('[ZONAS_STORE] Synced create applied, localStorage updated.');
+    },
+
+    applySyncedUpdate(id, updatedItemData) {
+      const syncStore = useSyncStore();
+      console.log(`[ZONAS_STORE] Applying synced update for id: ${id}`);
+      const index = this.zonas.findIndex(z => z.id === id);
+      if (index !== -1) {
+        this.zonas[index] = { ...this.zonas[index], ...updatedItemData, _isTemp: false };
+        syncStore.saveToLocalStorage('zonas', this.zonas);
+        console.log('[ZONAS_STORE] Synced update applied, localStorage updated.');
+      } else {
+         console.warn(`[ZONAS_STORE] Could not find item with id ${id} to apply update.`);
+      }
+    },
+
+    applySyncedDelete(id) {
+      const syncStore = useSyncStore();
+      console.log(`[ZONAS_STORE] Applying synced delete for id: ${id}`);
+      const initialLength = this.zonas.length;
+      this.zonas = this.zonas.filter(z => z.id !== id);
+      if (this.zonas.length < initialLength) {
+        syncStore.saveToLocalStorage('zonas', this.zonas);
+        console.log('[ZONAS_STORE] Synced delete applied, localStorage updated.');
+      } else {
+        console.warn(`[ZONAS_STORE] Could not find item with id ${id} to apply delete.`);
+      }
     }
   }
 })


### PR DESCRIPTION
This commit introduces a comprehensive set of features and improvements to the Bitacora (Logbook) module:

1.  **Enriched Bitacora Store (`bitacoraStore.js`):**
    *   The store now fetches and manages enriched bitácora entries, automatically expanding related data like `actividad_realizada` (including its `tipo_actividades` for metric definitions and report formats), `siembra_asociada`, and `user_responsable`.
    *   Includes getters to provide sorted and filtered lists of these enriched entries.

2.  **Dynamic Bitacora Entry Card (`BitacoraEntryCard.vue`):**
    *   A new reusable component to display individual bitácora entries using Vuetify 3.
    *   Dynamically renders metric data based on the `formato_reporte` of the activity's type and the actual values stored in the bitácora entry's `metricas` field.

3.  **Refactored General Bitacora View (`BitacoraView.vue`):**
    *   The main view for all bitácora entries has been redesigned using Vuetify 3.
    *   It now uses `BitacoraEntryCard` for display and includes robust filtering (by siembra, actividad, date) and "load more" pagination.

4.  **Embedded Bitacora List (`EmbeddedBitacoraList.vue`):**
    *   A new component to show a compact, expandable list of recent bitácora entries.
    *   Can be filtered by `siembraId` or `actividadId`.
    *   Designed for embedding into other workspace views. Includes a "View All" link to the main `BitacoraView`.

5.  **Dynamic Bitacora Entry Form (`forms/BitacoraEntryForm.vue`):**
    *   A new form for creating and editing bitácora entries.
    *   Crucially, it dynamically generates input fields for metrics based on the selected "Actividad Realizada." It uses the activity's specific metric configuration in conjunction with its type's `formato_reporte` to render appropriate fields (text, select, number, boolean).

6.  **Workspace Integration:**
    *   **`SiembraWorkspace.vue`:**
        *   Old bitácora table has been removed.
        *   `EmbeddedBitacoraList` added to show recent entries for the current siembra.
        *   `BitacoraEntryForm` integrated via a dialog to allow adding new entries specific to the siembra.
    *   **`ActividadesWorkspace.vue`:**
        *   Old bitácora table (if present) has been removed/cleaned up.
        *   `EmbeddedBitacoraList` added to show recent entries for the current actividad.
        *   `BitacoraEntryForm` integrated via a dialog to allow adding new entries specific to the actividad.

These changes provide a more robust, user-friendly, and deeply integrated Bitacora system, leveraging Vuetify 3 for the UI and enabling detailed, dynamic metric tracking.